### PR TITLE
feat: Improve asset data loading and transaction list UI

### DIFF
--- a/src/components/EnhancedAssetTable.tsx
+++ b/src/components/EnhancedAssetTable.tsx
@@ -83,7 +83,7 @@ const EnhancedAssetTable = ({
   };
 
   const filteredAndSortedAssets = useMemo(() => {
-    let filtered = assets.filter((asset) => {
+    let filtered = assets.filter(asset => asset.quantity > 0).filter((asset) => {
       const displayType = getAssetDisplayType(asset);
       const matchesFilter = assetFilter === "all" || assetFilter === "Todos" || displayType === assetFilter;
 

--- a/src/components/ManualInvestmentTransactions.tsx
+++ b/src/components/ManualInvestmentTransactions.tsx
@@ -41,6 +41,7 @@ import * as XLSX from "xlsx";
 
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import {
   Select,
   SelectContent,
@@ -68,6 +69,9 @@ export function ManualInvestmentTransactions({
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
   const [importing, setImporting] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(10);
   const { toast } = useToast();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
@@ -489,6 +493,44 @@ export function ManualInvestmentTransactions({
 
   const positionSummary = calculateManualPositions(transactions).filter(p => p.quantity > 0);
 
+  const paginatedTransactions = useMemo(() => {
+    let filtered = transactions;
+    if (searchQuery.trim()) {
+      const terms = searchQuery.toLowerCase().trim().split(/\s+/);
+      filtered = filtered.filter((t) => {
+        const searchable = [
+          t.ticker,
+          t.asset_name || '',
+          t.transaction_type,
+          format(new Date(t.transaction_date), "dd/MM/yy"),
+        ].join(' ').toLowerCase();
+        return terms.every((term) => searchable.includes(term));
+      });
+    }
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    return filtered.slice(startIndex, startIndex + itemsPerPage);
+  }, [transactions, searchQuery, currentPage, itemsPerPage]);
+
+  const totalFilteredCount = useMemo(() => {
+    let filtered = transactions;
+    if (searchQuery.trim()) {
+      const terms = searchQuery.toLowerCase().trim().split(/\s+/);
+      filtered = filtered.filter((t) => {
+        const searchable = [
+          t.ticker,
+          t.asset_name || '',
+          t.transaction_type,
+          format(new Date(t.transaction_date), "dd/MM/yy"),
+        ].join(' ').toLowerCase();
+        return terms.every((term) => searchable.includes(term));
+      });
+    }
+    return filtered.length;
+  }, [transactions, searchQuery]);
+
+  const totalPages = Math.ceil(totalFilteredCount / itemsPerPage);
+
+
   return (
     <div className="space-y-4">
       {positionSummary.length > 0 && (
@@ -529,17 +571,49 @@ export function ManualInvestmentTransactions({
                     </TableRow>
                   ))}
                 </TableBody>
+
               </Table>
+
+              {totalPages > 1 && (
+                <div className="flex items-center justify-between mt-4 pb-2 px-2">
+                  <div className="text-sm text-muted-foreground">
+                    Mostrando {((currentPage - 1) * itemsPerPage) + 1} a {Math.min(currentPage * itemsPerPage, totalFilteredCount)} de {totalFilteredCount}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Select value={String(itemsPerPage)} onValueChange={(val) => { setItemsPerPage(Number(val)); setCurrentPage(1); }}>
+                      <SelectTrigger className="w-[80px] h-8"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="5">5</SelectItem>
+                        <SelectItem value="10">10</SelectItem>
+                        <SelectItem value="20">20</SelectItem>
+                        <SelectItem value="50">50</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Button variant="outline" size="sm" onClick={() => setCurrentPage(p => Math.max(1, p - 1))} disabled={currentPage === 1}>Anterior</Button>
+                    <span className="text-sm">Página {currentPage} de {totalPages}</span>
+                    <Button variant="outline" size="sm" onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))} disabled={currentPage === totalPages}>Próxima</Button>
+                  </div>
+                </div>
+              )}
             </div>
+
           </CardContent>
         </Card>
       )}
 
       <Card>
+
         <CardHeader>
           <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
             <CardTitle className="text-base sm:text-lg">Histórico de Transações</CardTitle>
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <Input
+                placeholder="Buscar (ex: PETR4 Compra)..."
+                value={searchQuery}
+                onChange={(e) => { setSearchQuery(e.target.value); setCurrentPage(1); }}
+                className="w-full sm:w-64 h-9"
+              />
+
               <input
                 type="file"
                 accept=".xlsx,.xls,.csv"
@@ -677,7 +751,7 @@ export function ManualInvestmentTransactions({
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {transactions.map((transaction) => (
+                  {paginatedTransactions.map((transaction) => (
                     <TableRow key={transaction.id}>
                       <TableCell className="text-xs sm:text-sm">
                         {format(new Date(transaction.transaction_date), "dd/MM/yy")}
@@ -737,8 +811,32 @@ export function ManualInvestmentTransactions({
                     </TableRow>
                   ))}
                 </TableBody>
+
               </Table>
+
+              {totalPages > 1 && (
+                <div className="flex items-center justify-between mt-4 pb-2 px-2">
+                  <div className="text-sm text-muted-foreground">
+                    Mostrando {((currentPage - 1) * itemsPerPage) + 1} a {Math.min(currentPage * itemsPerPage, totalFilteredCount)} de {totalFilteredCount}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Select value={String(itemsPerPage)} onValueChange={(val) => { setItemsPerPage(Number(val)); setCurrentPage(1); }}>
+                      <SelectTrigger className="w-[80px] h-8"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="5">5</SelectItem>
+                        <SelectItem value="10">10</SelectItem>
+                        <SelectItem value="20">20</SelectItem>
+                        <SelectItem value="50">50</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Button variant="outline" size="sm" onClick={() => setCurrentPage(p => Math.max(1, p - 1))} disabled={currentPage === 1}>Anterior</Button>
+                    <span className="text-sm">Página {currentPage} de {totalPages}</span>
+                    <Button variant="outline" size="sm" onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))} disabled={currentPage === totalPages}>Próxima</Button>
+                  </div>
+                </div>
+              )}
             </div>
+
           )}
         </CardContent>
       </Card>

--- a/src/components/ManualInvestmentTransactions.tsx
+++ b/src/components/ManualInvestmentTransactions.tsx
@@ -487,7 +487,7 @@ export function ManualInvestmentTransactions({
     );
   }
 
-  const positionSummary = calculateManualPositions(transactions);
+  const positionSummary = calculateManualPositions(transactions).filter(p => p.quantity > 0);
 
   return (
     <div className="space-y-4">

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -119,6 +119,8 @@ export const TransactionList = ({ onTransactionChange }: TransactionListProps) =
   const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
   const [isOpen, setIsOpen] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(10);
   const fetchTransactions = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -338,6 +340,13 @@ export const TransactionList = ({ onTransactionChange }: TransactionListProps) =
     });
   }, [transactions, searchQuery]);
 
+  const paginatedTransactions = useMemo(() => {
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    return filteredTransactions.slice(startIndex, startIndex + itemsPerPage);
+  }, [filteredTransactions, currentPage, itemsPerPage]);
+
+  const totalPages = Math.ceil(filteredTransactions.length / itemsPerPage);
+
   const handleDelete = async () => {
     if (!transactionToDelete) return;
     setIsDeleting(true);
@@ -400,7 +409,7 @@ export const TransactionList = ({ onTransactionChange }: TransactionListProps) =
                         {dateRange?.from ? (dateRange.to ? (`${format(dateRange.from, "d/MM/yy")} - ${format(dateRange.to, "d/MM/yy")}`) : format(dateRange.from, "d/MM/yy")) : (<span>Período</span>)}
                       </Button>
                     </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start"><Calendar initialFocus mode="range" defaultMonth={dateRange?.from} selected={dateRange} onSelect={setDateRange} numberOfMonths={2} /></PopoverContent>
+                    <PopoverContent className="w-auto p-0" align="start"><Calendar initialFocus mode="range" defaultMonth={dateRange?.from} selected={dateRange} onSelect={(range) => { setDateRange(range); setCurrentPage(1); }} numberOfMonths={2} /></PopoverContent>
                   </Popover>
                 </div>
 
@@ -417,14 +426,14 @@ export const TransactionList = ({ onTransactionChange }: TransactionListProps) =
                 <Input
                   placeholder="Buscar por descrição, categoria, valor, data..."
                   value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
+                  onChange={(e) => { setSearchQuery(e.target.value); setCurrentPage(1); }}
                   className="pl-9"
                 />
               </div>
 
               <ScrollArea className="h-72"><div className="space-y-4 pr-4">
                 {loading ? renderSkeleton() : error ? <div className="text-center py-8 text-destructive flex flex-col items-center gap-2"><AlertTriangle className="h-8 w-8" /><p>{error}</p></div> : filteredTransactions.length === 0 ? <div className="text-center py-8 text-muted-foreground"><p>{searchQuery.trim() ? 'Nenhuma transação encontrada para a busca.' : 'Nenhuma transação encontrada para os filtros selecionados.'}</p></div> : (
-                    filteredTransactions.map((transaction) => {
+                    paginatedTransactions.map((transaction) => {
                       const iconName = getCategoryIcon(transaction.category, userCategories.map(c => ({ name: c.name, icon: c.icon, color: c.color })));
                       const iconColor = getCategoryColor(transaction.category, userCategories.map(c => ({ name: c.name, icon: c.icon, color: c.color })));
                       const IconComponent = (LucideIcons as any)[iconName] || LucideIcons.CircleDot;
@@ -470,6 +479,29 @@ export const TransactionList = ({ onTransactionChange }: TransactionListProps) =
                     })
                 )}
               </div></ScrollArea>
+
+              {/* Pagination Controls */}
+              {totalPages > 1 && (
+                <div className="flex items-center justify-between mt-4">
+                  <div className="text-sm text-muted-foreground">
+                    Mostrando {((currentPage - 1) * itemsPerPage) + 1} a {Math.min(currentPage * itemsPerPage, filteredTransactions.length)} de {filteredTransactions.length}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Select value={String(itemsPerPage)} onValueChange={(val) => { setItemsPerPage(Number(val)); setCurrentPage(1); }}>
+                      <SelectTrigger className="w-[80px] h-8"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="5">5</SelectItem>
+                        <SelectItem value="10">10</SelectItem>
+                        <SelectItem value="20">20</SelectItem>
+                        <SelectItem value="50">50</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Button variant="outline" size="sm" onClick={() => setCurrentPage(p => Math.max(1, p - 1))} disabled={currentPage === 1}>Anterior</Button>
+                    <span className="text-sm">Página {currentPage} de {totalPages}</span>
+                    <Button variant="outline" size="sm" onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))} disabled={currentPage === totalPages}>Próxima</Button>
+                  </div>
+                </div>
+              )}
             </CardContent>
           </CollapsibleContent>
         </Collapsible>

--- a/src/hooks/useB3Data.ts
+++ b/src/hooks/useB3Data.ts
@@ -538,28 +538,50 @@ export const useB3Data = () => {
             };
           });
 
-          const enhancedManual = manualPositions.map((pos) => {
-             // Determine correct ticker for lookup
-             const lookupTicker = pos.ticker.match(/^[A-Z]{4}\d{1,2}$/) ? `${pos.ticker}.SA` : (pos.ticker.endsWith(".SA") ? pos.ticker : `${pos.ticker}.SA`);
+          const getQuantityAtDate = (ticker: string, dateStr: string, txs: any[]) => {
+             const date = new Date(dateStr);
+             let qty = 0;
+             for (const tx of txs) {
+                 const txDate = new Date(tx.transaction_date);
+                 if (txDate > date) break;
+                 if (tx.ticker === ticker || tx.ticker === ticker.replace('.SA', '')) {
+                     if (tx.transaction_type === 'buy') qty += tx.quantity;
+                     else if (tx.transaction_type === 'sell') qty -= tx.quantity;
+                 }
+             }
+             return Math.max(0, qty);
+          };
 
+          const sortedManualTxs = [...manualTransactions].sort((a, b) => new Date(a.transaction_date).getTime() - new Date(b.transaction_date).getTime());
+
+          const enhancedManual = manualPositions.map((pos) => {
+             const lookupTicker = pos.ticker.match(/^[A-Z]{4}\d{1,2}$/) ? `${pos.ticker}.SA` : (pos.ticker.endsWith(".SA") ? pos.ticker : `${pos.ticker}.SA`);
              const yfinanceAsset = yfinanceData.find((asset) => asset.ticker === lookupTicker);
 
-             const currentPrice = yfinanceAsset?.preco_atual || pos.averagePrice; // Fallback to avg price if no quote
+             const currentPrice = yfinanceAsset?.preco_atual || pos.averagePrice;
              const marketValue = currentPrice * pos.quantity;
              const cost = pos.totalCost;
              const profitLoss = marketValue - cost;
              const profitability = cost > 0 ? (profitLoss / cost) * 100 : 0;
 
-             // Calculate dividends and Yield on Cost
-             // `dividendos_12m` from yfinance is dividends per share over last 12 months.
-             const dividendPerShare = yfinanceAsset?.dividendos_12m || 0;
-             const totalDividendsReceived = dividendPerShare * pos.quantity;
-             const yieldOnCostCalc = pos.averagePrice > 0 ? (dividendPerShare / pos.averagePrice) * 100 : 0;
+             let totalDividendsReceived = 0;
+             if (yfinanceAsset?.historico_dividendos && Array.isArray(yfinanceAsset.historico_dividendos)) {
+                 yfinanceAsset.historico_dividendos.forEach((div: any) => {
+                     const qtyAtDiv = getQuantityAtDate(pos.ticker, div.date, sortedManualTxs);
+                     if (qtyAtDiv > 0 && div.amount) {
+                         totalDividendsReceived += (div.amount * qtyAtDiv);
+                     }
+                 });
+             } else if (yfinanceAsset?.dividendos_12m) {
+                 totalDividendsReceived = yfinanceAsset.dividendos_12m * pos.quantity;
+             }
+
+             const yieldOnCostCalc = pos.totalCost > 0 ? (totalDividendsReceived / pos.totalCost) * 100 : 0;
 
              return {
                symbol: pos.ticker,
                name: yfinanceAsset?.nome || pos.asset_name,
-               type: pos.asset_type, // Use the asset_type from the manual position
+               type: pos.asset_type,
                subtype: null,
                currentPrice,
                quantity: pos.quantity,
@@ -573,14 +595,10 @@ export const useB3Data = () => {
              };
           });
 
-          // Fix potential dividend calculation issues in Pluggy data
           const enhancedPluggyFixed = enhancedPluggy.map(p => {
-             // Ensure dividends are calculated as Total Dividends (per share * quantity)
-             // Pluggy data was initially assigned per-share dividends to `accumulatedDividends`.
              const divPerShare = p.accumulatedDividends;
              const totalDivs = divPerShare * p.quantity;
              const yoc = p.averagePrice > 0 ? (divPerShare / p.averagePrice) * 100 : 0;
-
              return {
                 ...p,
                 accumulatedDividends: totalDivs,

--- a/supabase/functions/yfinance-data/index.ts
+++ b/supabase/functions/yfinance-data/index.ts
@@ -39,10 +39,10 @@ async function fetchTickerData(ticker: string): Promise<AssetData> {
   };
 
   // Tentar a API v8 chart primeiro (mais confiável)
-  const oneYearAgo = Math.floor(Date.now() / 1000) - 365 * 24 * 60 * 60;
+  const oneYearAgo = 0;
   const now = Math.floor(Date.now() / 1000);
   
-  const chartUrl = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(ticker)}?period1=${oneYearAgo}&period2=${now}&interval=1mo&events=div`;
+  const chartUrl = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(ticker)}?period1=0&period2=${now}&interval=1mo&events=div`;
   
   console.log(`Fetching chart data from: ${chartUrl}`);
   


### PR DESCRIPTION
- Modifies the Yahoo Finance fetch URL to retrieve dividends since the asset's inception instead of just the last 12 months.
- Hides assets from "Posições Atuais" / "Meus Ativos" that have been completely sold.
- Implements pagination in the `TransactionList` with customizable rows per page, maintaining the existing smart search and date filters.

---
*PR created automatically by Jules for task [17777793897148438143](https://jules.google.com/task/17777793897148438143) started by @dnsaranha*