### PR TITLE
Fix missing historical dividend records when adding investments

### DIFF
--- a/supabase/functions/yfinance-data/index.ts
+++ b/supabase/functions/yfinance-data/index.ts
@@ -41,8 +41,9 @@ async function fetchTickerData(ticker: string): Promise<AssetData> {
   // Tentar a API v8 chart primeiro (mais confiável)
   const oneYearAgo = Math.floor(Date.now() / 1000) - 365 * 24 * 60 * 60;
   const now = Math.floor(Date.now() / 1000);
+  const period1 = 0; // Fetch all historical data
   
-  const chartUrl = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(ticker)}?period1=${oneYearAgo}&period2=${now}&interval=1mo&events=div`;
+  const chartUrl = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(ticker)}?period1=${period1}&period2=${now}&interval=1mo&events=div`;
   
   console.log(`Fetching chart data from: ${chartUrl}`);
   
@@ -93,7 +94,10 @@ async function fetchTickerData(ticker: string): Promise<AssetData> {
     if (divData && divData.amount) {
       const date = new Date(parseInt(timestamp) * 1000).toISOString().split('T')[0];
       historico_dividendos.push({ date, amount: divData.amount });
-      dividendos_12m += divData.amount;
+
+      if (parseInt(timestamp) >= oneYearAgo) {
+        dividendos_12m += divData.amount;
+      }
     }
   }
 


### PR DESCRIPTION
This change ensures that dividend records older than 1 year (e.g., from 2019) are successfully imported when users add investment assets like RBRR11, PETR4, and MXRF11. It fetches all the historical dividends from Yahoo Finance instead of just the most recent year, while preserving the correct calculation of `dividendos_12m`.

---
*PR created automatically by Jules for task [1884827856334841097](https://jules.google.com/task/1884827856334841097) started by @dnsaranha*