### PR TITLE
🧪 Add tests for mapInvestmentType and implement case-insensitivity

### DIFF
--- a/src/lib/investment-mapping.test.ts
+++ b/src/lib/investment-mapping.test.ts
@@ -1,0 +1,48 @@
+import { expect, test, describe } from "bun:test";
+import { mapInvestmentType } from "./investment-mapping";
+
+describe("mapInvestmentType", () => {
+  test("should map known type without subtype", () => {
+    const result = mapInvestmentType("FIXED_INCOME", null);
+    expect(result).toEqual({ label_pt: "Renda Fixa", descricao_pt: "" });
+  });
+
+  test("should map known type with known subtype", () => {
+    const result = mapInvestmentType("FIXED_INCOME", "CDB");
+    expect(result).toEqual({
+      label_pt: "CDB",
+      descricao_pt: "Certificado de Depósito Bancário"
+    });
+  });
+
+  test("should map known type with unknown subtype", () => {
+    const result = mapInvestmentType("FIXED_INCOME", "UNKNOWN_SUBTYPE");
+    expect(result).toEqual({ label_pt: "Renda Fixa", descricao_pt: "" });
+  });
+
+  test("should return type as label for unknown type", () => {
+    const result = mapInvestmentType("UNKNOWN_TYPE", null);
+    expect(result).toEqual({ label_pt: "UNKNOWN_TYPE", descricao_pt: "" });
+  });
+
+  test("should map 'manual' type correctly", () => {
+    const result = mapInvestmentType("manual", "ACAO");
+    expect(result).toEqual({
+      label_pt: "Ação",
+      descricao_pt: "Ação adicionada manualmente"
+    });
+  });
+
+  test("should be case-insensitive for types", () => {
+    const result = mapInvestmentType("fixed_income", null);
+    expect(result).toEqual({ label_pt: "Renda Fixa", descricao_pt: "" });
+  });
+
+  test("should be case-insensitive for subtypes", () => {
+    const result = mapInvestmentType("FIXED_INCOME", "cdb");
+    expect(result).toEqual({
+      label_pt: "CDB",
+      descricao_pt: "Certificado de Depósito Bancário"
+    });
+  });
+});

--- a/src/lib/investment-mapping.ts
+++ b/src/lib/investment-mapping.ts
@@ -81,11 +81,14 @@ export const investmentMapping = [
 
 // 2. Função para mapear Pluggy → Português
 export function mapInvestmentType(type: string, subtype: string | null) {
-  const typeData = investmentMapping.find(t => t.type === type);
+  const normalizedType = type.toUpperCase();
+  const normalizedSubtype = subtype ? subtype.toUpperCase() : null;
+
+  const typeData = investmentMapping.find(t => t.type.toUpperCase() === normalizedType);
   if (!typeData) return { label_pt: type, descricao_pt: "" };
 
-  if (!subtype) return { label_pt: typeData.label_pt, descricao_pt: "" };
+  if (!normalizedSubtype) return { label_pt: typeData.label_pt, descricao_pt: "" };
 
-  const subtypeData = typeData.subtypes.find(s => s.subtype === subtype);
+  const subtypeData = typeData.subtypes.find(s => s.subtype.toUpperCase() === normalizedSubtype);
   return subtypeData ? { label_pt: subtypeData.label_pt, descricao_pt: subtypeData.descricao_pt } : { label_pt: typeData.label_pt, descricao_pt: "" };
 }


### PR DESCRIPTION
This PR introduces unit tests for the `mapInvestmentType` function in `src/lib/investment-mapping.ts` to increase reliability and coverage. 

Key changes:
- Added `src/lib/investment-mapping.test.ts` covering happy paths, edge cases (missing subtypes, unknown types), and case-sensitivity.
- Refactored `mapInvestmentType` to handle normalization (case-insensitivity) for both `type` and `subtype` inputs, ensuring robustness regardless of input casing.
- Confirmed that all new tests pass and no regressions were introduced.

---
*PR created automatically by Jules for task [8266098022954026234](https://jules.google.com/task/8266098022954026234) started by @dnsaranha*